### PR TITLE
Refactoring PR #3: Add lib/github_api.sh and lib/validation.sh

### DIFF
--- a/.github/actions/auto-triage/auto_triage/lib/common.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/common.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+#
+# common.sh - Shared utilities for auto-triage scripts
+#
+# Provides:
+# - Color output functions (log_info, log_error, log_warn, log_success)
+# - Path resolution functions (get_data_dir, get_output_dir, get_logs_dir)
+# - Error handling helpers (die, warn, check_command)
+# - JSON manipulation helpers (jq_safe, json_get)
+# - Environment variable helpers (require_env, get_env_with_default)
+#
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
+# Or from a script in auto_triage/: source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+#
+
+# Prevent double-sourcing
+if [ -n "${AUTO_TRIAGE_COMMON_LOADED:-}" ]; then
+    return 0
+fi
+AUTO_TRIAGE_COMMON_LOADED=1
+
+# ------------------------------------------------------------------------------
+# Color constants (only if stdout is a TTY, otherwise unset for piping/logs)
+# ------------------------------------------------------------------------------
+if [ -t 1 ]; then
+    AUTO_TRIAGE_RED='\033[0;31m'
+    AUTO_TRIAGE_GREEN='\033[0;32m'
+    AUTO_TRIAGE_YELLOW='\033[1;33m'
+    AUTO_TRIAGE_BLUE='\033[0;34m'
+    AUTO_TRIAGE_NC='\033[0m'
+else
+    AUTO_TRIAGE_RED=''
+    AUTO_TRIAGE_GREEN=''
+    AUTO_TRIAGE_YELLOW=''
+    AUTO_TRIAGE_BLUE=''
+    AUTO_TRIAGE_NC=''
+fi
+
+# ------------------------------------------------------------------------------
+# Root path resolution - auto-detect when sourced from lib/common.sh
+# ------------------------------------------------------------------------------
+_AUTO_TRIAGE_LIB_DIR="${_AUTO_TRIAGE_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" 2>/dev/null && pwd)}"
+AUTO_TRIAGE_ROOT="${AUTO_TRIAGE_ROOT:-$(cd "${_AUTO_TRIAGE_LIB_DIR}/.." 2>/dev/null && pwd)}"
+
+# ------------------------------------------------------------------------------
+# Color output functions
+# ------------------------------------------------------------------------------
+
+# Log informational message (blue)
+log_info() {
+    echo -e "${AUTO_TRIAGE_BLUE}$*${AUTO_TRIAGE_NC}"
+}
+
+# Log error message (red) to stderr
+log_error() {
+    echo -e "${AUTO_TRIAGE_RED}$*${AUTO_TRIAGE_NC}" >&2
+}
+
+# Log warning message (yellow) to stderr
+log_warn() {
+    echo -e "${AUTO_TRIAGE_YELLOW}$*${AUTO_TRIAGE_NC}" >&2
+}
+
+# Log success message (green)
+log_success() {
+    echo -e "${AUTO_TRIAGE_GREEN}$*${AUTO_TRIAGE_NC}"
+}
+
+# ------------------------------------------------------------------------------
+# Path resolution functions
+# Returns canonical paths relative to AUTO_TRIAGE_ROOT
+# ------------------------------------------------------------------------------
+
+# Get the data directory path (auto_triage/data)
+get_data_dir() {
+    local root="${1:-$AUTO_TRIAGE_ROOT}"
+    if [ -z "$root" ]; then
+        echo "auto_triage/data"
+        return
+    fi
+    echo "${root}/auto_triage/data"
+}
+
+# Get the output directory path (auto_triage/output)
+get_output_dir() {
+    local root="${1:-$AUTO_TRIAGE_ROOT}"
+    if [ -z "$root" ]; then
+        echo "auto_triage/output"
+        return
+    fi
+    echo "${root}/auto_triage/output"
+}
+
+# Get the logs directory path (auto_triage/logs)
+get_logs_dir() {
+    local root="${1:-$AUTO_TRIAGE_ROOT}"
+    if [ -z "$root" ]; then
+        echo "auto_triage/logs"
+        return
+    fi
+    echo "${root}/auto_triage/logs"
+}
+
+# ------------------------------------------------------------------------------
+# Error handling helpers
+# ------------------------------------------------------------------------------
+
+# Exit immediately with error message
+# Usage: die "Error message"
+die() {
+    log_error "Error: $*"
+    exit 1
+}
+
+# Print warning but continue
+# Usage: warn "Warning message"
+warn() {
+    log_warn "Warning: $*"
+}
+
+# Check that a command exists; die if not
+# Usage: check_command jq gh
+check_command() {
+    local cmd
+    for cmd in "$@"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            die "$cmd is required but not found in PATH."
+        fi
+    done
+}
+
+# ------------------------------------------------------------------------------
+# JSON manipulation helpers
+# ------------------------------------------------------------------------------
+
+# Run jq with safe fallback for missing/invalid files
+# Usage: result=$(jq_safe -r '.key' file.json) || default_value
+# Returns exit 1 if jq fails, so use with: val=$(jq_safe ...) || val="default"
+jq_safe() {
+    if [ $# -lt 2 ]; then
+        echo "Usage: jq_safe <jq_args> <file>" >&2
+        return 1
+    fi
+    local file="${*: -1}"
+    local jq_args=("${@:1:$#-1}")
+    if [ ! -f "$file" ]; then
+        return 1
+    fi
+    jq "${jq_args[@]}" "$file" 2>/dev/null || return 1
+}
+
+# Get JSON value with optional default
+# Usage: val=$(json_get .key file.json "default")
+# Usage: val=$(json_get .key file.json)
+json_get() {
+    local path="$1"
+    local file="$2"
+    local default="${3:-}"
+    local result
+    result=$(jq_safe -r "$path" "$file") || true
+    if [ -n "$result" ] && [ "$result" != "null" ]; then
+        echo "$result"
+    else
+        echo "$default"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Environment variable helpers
+# ------------------------------------------------------------------------------
+
+# Require an environment variable; die if unset or empty
+# Usage: require_env GITHUB_TOKEN
+# Usage: require_env SLACK_BOT_TOKEN "Set SLACK_BOT_TOKEN to send notifications"
+require_env() {
+    local var_name="$1"
+    local msg="${2:-$var_name must be set}"
+    local val="${!var_name:-}"
+    if [ -z "$val" ]; then
+        die "$msg"
+    fi
+}
+
+# Get env var with default value
+# Usage: token=$(get_env_with_default COPILOT_PAT "$GH_TOKEN")
+get_env_with_default() {
+    local var_name="$1"
+    local default="$2"
+    local val="${!var_name:-}"
+    if [ -n "$val" ]; then
+        echo "$val"
+    else
+        echo "$default"
+    fi
+}

--- a/.github/actions/auto-triage/auto_triage/lib/common.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/common.sh
@@ -3,161 +3,101 @@
 # common.sh - Shared utilities for auto-triage scripts
 #
 # Provides:
-# - Color output functions (log_info, log_error, log_warn, log_success)
-# - Path resolution functions (get_data_dir, get_output_dir, get_logs_dir)
-# - Error handling helpers (die, warn, check_command)
-# - JSON manipulation helpers (jq_safe, json_get)
-# - Environment variable helpers (require_env, get_env_with_default)
+#   Logging    - log_info, log_error, log_warn, log_success
+#   Paths      - get_data_dir, get_output_dir, get_logs_dir
+#   Errors     - die, warn, check_command
+#   JSON       - jq_safe, json_get
+#   Env vars   - require_env, get_env_with_default
 #
-# Usage: source "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
-# Or from a script in auto_triage/: source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+# Usage (from any script under auto_triage/):
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
 #
 
-# Prevent double-sourcing
-if [ -n "${AUTO_TRIAGE_COMMON_LOADED:-}" ]; then
+# Guard against double-sourcing
+if [ -n "${_AUTO_TRIAGE_COMMON_LOADED:-}" ]; then
     return 0
 fi
-AUTO_TRIAGE_COMMON_LOADED=1
+_AUTO_TRIAGE_COMMON_LOADED=1
 
-# ------------------------------------------------------------------------------
-# Color constants (only if stdout is a TTY, otherwise unset for piping/logs)
-# ------------------------------------------------------------------------------
-if [ -t 1 ]; then
-    AUTO_TRIAGE_RED='\033[0;31m'
-    AUTO_TRIAGE_GREEN='\033[0;32m'
-    AUTO_TRIAGE_YELLOW='\033[1;33m'
-    AUTO_TRIAGE_BLUE='\033[0;34m'
-    AUTO_TRIAGE_NC='\033[0m'
+# ==============================================================================
+# Root path resolution
+# ==============================================================================
+# auto_triage/lib/common.sh  ->  lib dir is dirname, root is one level up.
+_AUTO_TRIAGE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTO_TRIAGE_ROOT="${AUTO_TRIAGE_ROOT:-$(cd "$_AUTO_TRIAGE_LIB_DIR/.." && pwd)}"
+
+# ==============================================================================
+# Colors  (enabled when stdout is a TTY *or* inside CI, matching existing scripts)
+# ==============================================================================
+if [ -t 1 ] || [ "${CI:-}" = "true" ]; then
+    _AT_RED='\033[0;31m'
+    _AT_GREEN='\033[0;32m'
+    _AT_YELLOW='\033[1;33m'
+    _AT_BLUE='\033[0;34m'
+    _AT_NC='\033[0m'
 else
-    AUTO_TRIAGE_RED=''
-    AUTO_TRIAGE_GREEN=''
-    AUTO_TRIAGE_YELLOW=''
-    AUTO_TRIAGE_BLUE=''
-    AUTO_TRIAGE_NC=''
+    _AT_RED=''
+    _AT_GREEN=''
+    _AT_YELLOW=''
+    _AT_BLUE=''
+    _AT_NC=''
 fi
 
-# ------------------------------------------------------------------------------
-# Root path resolution - auto-detect when sourced from lib/common.sh
-# ------------------------------------------------------------------------------
-_AUTO_TRIAGE_LIB_DIR="${_AUTO_TRIAGE_LIB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" 2>/dev/null && pwd)}"
-AUTO_TRIAGE_ROOT="${AUTO_TRIAGE_ROOT:-$(cd "${_AUTO_TRIAGE_LIB_DIR}/.." 2>/dev/null && pwd)}"
+# ==============================================================================
+# Logging
+# ==============================================================================
 
-# ------------------------------------------------------------------------------
-# Color output functions
-# ------------------------------------------------------------------------------
+log_info()    { echo -e "${_AT_BLUE}$*${_AT_NC}"; }        # informational (blue)
+log_success() { echo -e "${_AT_GREEN}$*${_AT_NC}"; }       # success       (green)
+log_warn()    { echo -e "${_AT_YELLOW}$*${_AT_NC}" >&2; }  # warning       (yellow, stderr)
+log_error()   { echo -e "${_AT_RED}$*${_AT_NC}" >&2; }     # error         (red, stderr)
 
-# Log informational message (blue)
-log_info() {
-    echo -e "${AUTO_TRIAGE_BLUE}$*${AUTO_TRIAGE_NC}"
-}
+# ==============================================================================
+# Error handling
+# ==============================================================================
 
-# Log error message (red) to stderr
-log_error() {
-    echo -e "${AUTO_TRIAGE_RED}$*${AUTO_TRIAGE_NC}" >&2
-}
+# Print error and exit 1.
+die() { log_error "Error: $*"; exit 1; }
 
-# Log warning message (yellow) to stderr
-log_warn() {
-    echo -e "${AUTO_TRIAGE_YELLOW}$*${AUTO_TRIAGE_NC}" >&2
-}
+# Print warning and continue.
+warn() { log_warn "Warning: $*"; }
 
-# Log success message (green)
-log_success() {
-    echo -e "${AUTO_TRIAGE_GREEN}$*${AUTO_TRIAGE_NC}"
-}
-
-# ------------------------------------------------------------------------------
-# Path resolution functions
-# Returns canonical paths relative to AUTO_TRIAGE_ROOT
-# ------------------------------------------------------------------------------
-
-# Get the data directory path (auto_triage/data)
-get_data_dir() {
-    local root="${1:-$AUTO_TRIAGE_ROOT}"
-    if [ -z "$root" ]; then
-        echo "auto_triage/data"
-        return
-    fi
-    echo "${root}/auto_triage/data"
-}
-
-# Get the output directory path (auto_triage/output)
-get_output_dir() {
-    local root="${1:-$AUTO_TRIAGE_ROOT}"
-    if [ -z "$root" ]; then
-        echo "auto_triage/output"
-        return
-    fi
-    echo "${root}/auto_triage/output"
-}
-
-# Get the logs directory path (auto_triage/logs)
-get_logs_dir() {
-    local root="${1:-$AUTO_TRIAGE_ROOT}"
-    if [ -z "$root" ]; then
-        echo "auto_triage/logs"
-        return
-    fi
-    echo "${root}/auto_triage/logs"
-}
-
-# ------------------------------------------------------------------------------
-# Error handling helpers
-# ------------------------------------------------------------------------------
-
-# Exit immediately with error message
-# Usage: die "Error message"
-die() {
-    log_error "Error: $*"
-    exit 1
-}
-
-# Print warning but continue
-# Usage: warn "Warning message"
-warn() {
-    log_warn "Warning: $*"
-}
-
-# Check that a command exists; die if not
-# Usage: check_command jq gh
+# Die if any of the listed commands are missing.
+#   check_command jq gh copilot
 check_command() {
     local cmd
     for cmd in "$@"; do
-        if ! command -v "$cmd" >/dev/null 2>&1; then
-            die "$cmd is required but not found in PATH."
-        fi
+        command -v "$cmd" >/dev/null 2>&1 || die "$cmd is required but not found in PATH."
     done
 }
 
-# ------------------------------------------------------------------------------
-# JSON manipulation helpers
-# ------------------------------------------------------------------------------
+# ==============================================================================
+# Path helpers  (canonical paths relative to AUTO_TRIAGE_ROOT)
+# ==============================================================================
 
-# Run jq with safe fallback for missing/invalid files
-# Usage: result=$(jq_safe -r '.key' file.json) || default_value
-# Returns exit 1 if jq fails, so use with: val=$(jq_safe ...) || val="default"
+get_data_dir()   { echo "${1:-$AUTO_TRIAGE_ROOT}/auto_triage/data"; }
+get_output_dir() { echo "${1:-$AUTO_TRIAGE_ROOT}/auto_triage/output"; }
+get_logs_dir()   { echo "${1:-$AUTO_TRIAGE_ROOT}/auto_triage/logs"; }
+
+# ==============================================================================
+# JSON helpers  (require jq at call-time, not at source-time)
+# ==============================================================================
+
+# Safe jq wrapper: returns 1 when the file is missing or jq fails.
+#   result=$(jq_safe -r '.key' file.json) || result="default"
 jq_safe() {
-    if [ $# -lt 2 ]; then
-        echo "Usage: jq_safe <jq_args> <file>" >&2
-        return 1
-    fi
-    local file="${*: -1}"
-    local jq_args=("${@:1:$#-1}")
-    if [ ! -f "$file" ]; then
-        return 1
-    fi
-    jq "${jq_args[@]}" "$file" 2>/dev/null || return 1
+    [ $# -ge 2 ] || { echo "Usage: jq_safe <jq_args...> <file>" >&2; return 1; }
+    local file="${@: -1}"
+    [ -f "$file" ] || return 1
+    jq "${@:1:$#-1}" "$file" 2>/dev/null
 }
 
-# Get JSON value with optional default
-# Usage: val=$(json_get .key file.json "default")
-# Usage: val=$(json_get .key file.json)
+# Convenience: extract a value or fall back to a default.
+#   val=$(json_get .key file.json "fallback")
 json_get() {
-    local path="$1"
-    local file="$2"
-    local default="${3:-}"
+    local jq_path="$1" file="$2" default="${3:-}"
     local result
-    result=$(jq_safe -r "$path" "$file") || true
+    result=$(jq_safe -r "$jq_path" "$file") || true
     if [ -n "$result" ] && [ "$result" != "null" ]; then
         echo "$result"
     else
@@ -165,31 +105,22 @@ json_get() {
     fi
 }
 
-# ------------------------------------------------------------------------------
+# ==============================================================================
 # Environment variable helpers
-# ------------------------------------------------------------------------------
+# ==============================================================================
 
-# Require an environment variable; die if unset or empty
-# Usage: require_env GITHUB_TOKEN
-# Usage: require_env SLACK_BOT_TOKEN "Set SLACK_BOT_TOKEN to send notifications"
+# Die when a required env var is unset or empty.
+#   require_env GITHUB_TOKEN
+#   require_env SLACK_BOT_TOKEN "Set SLACK_BOT_TOKEN to send notifications"
 require_env() {
     local var_name="$1"
     local msg="${2:-$var_name must be set}"
-    local val="${!var_name:-}"
-    if [ -z "$val" ]; then
-        die "$msg"
-    fi
+    [ -n "${!var_name:-}" ] || die "$msg"
 }
 
-# Get env var with default value
-# Usage: token=$(get_env_with_default COPILOT_PAT "$GH_TOKEN")
+# Return the value of an env var, or a default if unset/empty.
+#   token=$(get_env_with_default COPILOT_PAT "$GH_TOKEN")
 get_env_with_default() {
-    local var_name="$1"
-    local default="$2"
-    local val="${!var_name:-}"
-    if [ -n "$val" ]; then
-        echo "$val"
-    else
-        echo "$default"
-    fi
+    local val="${!1:-}"
+    echo "${val:-$2}"
 }

--- a/.github/actions/auto-triage/auto_triage/lib/common.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/common.sh
@@ -90,9 +90,7 @@ jq_safe() {
     command -v jq >/dev/null 2>&1 || return 1
     local file="${@: -1}"
     [ -f "$file" ] || return 1
-    jq "${@:1:$#-1}" "$file" 2>/dev/null
-    local status=$?
-    [ "$status" -eq 0 ] || return 1
+    jq "${@:1:$#-1}" "$file" 2>/dev/null || return 1
 }
 
 # Convenience: extract a value or fall back to a default.

--- a/.github/actions/auto-triage/auto_triage/lib/common.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/common.sh
@@ -47,10 +47,10 @@ fi
 # Logging
 # ==============================================================================
 
-log_info()    { echo -e "${_AT_BLUE}$*${_AT_NC}"; }        # informational (blue)
-log_success() { echo -e "${_AT_GREEN}$*${_AT_NC}"; }       # success       (green)
-log_warn()    { echo -e "${_AT_YELLOW}$*${_AT_NC}" >&2; }  # warning       (yellow, stderr)
-log_error()   { echo -e "${_AT_RED}$*${_AT_NC}" >&2; }     # error         (red, stderr)
+log_info()    { printf '%b\n' "${_AT_BLUE}$*${_AT_NC}"; }        # informational (blue)
+log_success() { printf '%b\n' "${_AT_GREEN}$*${_AT_NC}"; }       # success       (green)
+log_warn()    { printf '%b\n' "${_AT_YELLOW}$*${_AT_NC}" >&2; }  # warning       (yellow, stderr)
+log_error()   { printf '%b\n' "${_AT_RED}$*${_AT_NC}" >&2; }     # error         (red, stderr)
 
 # ==============================================================================
 # Error handling
@@ -87,14 +87,18 @@ get_logs_dir()   { echo "${1:-$AUTO_TRIAGE_ROOT}/auto_triage/logs"; }
 #   result=$(jq_safe -r '.key' file.json) || result="default"
 jq_safe() {
     [ $# -ge 2 ] || { echo "Usage: jq_safe <jq_args...> <file>" >&2; return 1; }
+    command -v jq >/dev/null 2>&1 || return 1
     local file="${@: -1}"
     [ -f "$file" ] || return 1
     jq "${@:1:$#-1}" "$file" 2>/dev/null
+    local status=$?
+    [ "$status" -eq 0 ] || return 1
 }
 
 # Convenience: extract a value or fall back to a default.
 #   val=$(json_get .key file.json "fallback")
 json_get() {
+    [ $# -ge 2 ] || { echo "Usage: json_get <jq_path> <file> [default]" >&2; return 1; }
     local jq_path="$1" file="$2" default="${3:-}"
     local result
     result=$(jq_safe -r "$jq_path" "$file") || true
@@ -113,6 +117,7 @@ json_get() {
 #   require_env GITHUB_TOKEN
 #   require_env SLACK_BOT_TOKEN "Set SLACK_BOT_TOKEN to send notifications"
 require_env() {
+    [ $# -ge 1 ] || die "Usage: require_env VAR_NAME [message]"
     local var_name="$1"
     local msg="${2:-$var_name must be set}"
     [ -n "${!var_name:-}" ] || die "$msg"
@@ -121,6 +126,11 @@ require_env() {
 # Return the value of an env var, or a default if unset/empty.
 #   token=$(get_env_with_default COPILOT_PAT "$GH_TOKEN")
 get_env_with_default() {
-    local val="${!1:-}"
-    echo "${val:-$2}"
+    [ $# -ge 2 ] || die "get_env_with_default: expected VAR_NAME and DEFAULT arguments"
+    local var_name="$1" default_value="$2"
+    if ! [[ "$var_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        die "get_env_with_default: invalid environment variable name: '$var_name'"
+    fi
+    local val="${!var_name:-}"
+    echo "${val:-$default_value}"
 }

--- a/.github/actions/auto-triage/auto_triage/lib/config.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/config.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# config.sh - Centralised configuration for auto-triage scripts
+#
+# All values are overridable via environment variables so that tests and
+# alternative deployments can customise behaviour without editing code.
+#
+# Usage: source the file after common.sh
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/config.sh"
+#
+
+# Guard against double-sourcing
+if [ -n "${_AUTO_TRIAGE_CONFIG_LOADED:-}" ]; then
+    return 0
+fi
+_AUTO_TRIAGE_CONFIG_LOADED=1
+
+# ==============================================================================
+# Repository  (the repo being triaged, NOT the auto-triage repo itself)
+# ==============================================================================
+AT_OWNER="${AT_OWNER:-tenstorrent}"
+AT_REPO="${AT_REPO:-tt-metal}"
+AT_OWNER_REPO="${AT_OWNER}/${AT_REPO}"
+AT_BASE_URL="https://github.com/${AT_OWNER_REPO}"
+
+# ==============================================================================
+# Numeric constants  (used by more than one script)
+# ==============================================================================
+AT_BATCH_SIZE="${AT_BATCH_SIZE:-10}"            # commits per download batch
+AT_MAX_BATCHES="${AT_MAX_BATCHES:-100}"         # max commit range before failing
+AT_PER_PAGE="${AT_PER_PAGE:-100}"               # GitHub API results per page
+AT_FAILURE_LIMIT="${AT_FAILURE_LIMIT:-30}"      # consecutive failures before stopping boundary search
+
+# ==============================================================================
+# Feature flags  (mirror the action.yml inputs where relevant)
+# ==============================================================================
+AT_CUTOFF_COMMIT="${CUTOFF_COMMIT:-}"           # ignore runs newer than this SHA
+AT_REUSE_DATA="${REUSE_DATA:-false}"            # skip re-downloading data if present
+
+# ==============================================================================
+# Directory helpers  (thin wrappers around common.sh, adding mkdir + symlinks)
+# ==============================================================================
+
+# Create canonical data/logs/output directories and their convenience symlinks.
+# Call once during script initialisation (filter_triage.sh, auto_triage.sh, etc.)
+#
+#   setup_triage_dirs [root]
+#
+# Sets globals: CANON_DATA_DIR, CANON_LOGS_DIR, CANON_OUTPUT_DIR
+setup_triage_dirs() {
+    local root="${1:-$AUTO_TRIAGE_ROOT}"
+
+    CANON_DATA_DIR="$(get_data_dir "$root")"
+    CANON_LOGS_DIR="$(get_logs_dir "$root")"
+    CANON_OUTPUT_DIR="$(get_output_dir "$root")"
+
+    mkdir -p "$CANON_DATA_DIR" "$CANON_LOGS_DIR" "$CANON_OUTPUT_DIR"
+
+    # Convenience symlinks (./data -> auto_triage/data, etc.)
+    ln -sfn auto_triage/data   "${root}/data"
+    ln -sfn auto_triage/logs   "${root}/logs"
+    ln -sfn auto_triage/output "${root}/output"
+}

--- a/.github/actions/auto-triage/auto_triage/lib/config.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/config.sh
@@ -5,8 +5,7 @@
 # All values are overridable via environment variables so that tests and
 # alternative deployments can customise behaviour without editing code.
 #
-# Usage: source the file after common.sh
-#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/common.sh"
+# Usage: source this file (it pulls in common.sh automatically).
 #   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/config.sh"
 #
 
@@ -16,13 +15,18 @@ if [ -n "${_AUTO_TRIAGE_CONFIG_LOADED:-}" ]; then
 fi
 _AUTO_TRIAGE_CONFIG_LOADED=1
 
+# config.sh depends on common.sh (AUTO_TRIAGE_ROOT, get_data_dir, etc.)
+_CONFIG_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$_CONFIG_LIB_DIR/common.sh"
+
 # ==============================================================================
 # Repository  (the repo being triaged, NOT the auto-triage repo itself)
 # ==============================================================================
 AT_OWNER="${AT_OWNER:-tenstorrent}"
 AT_REPO="${AT_REPO:-tt-metal}"
-AT_OWNER_REPO="${AT_OWNER}/${AT_REPO}"
-AT_BASE_URL="https://github.com/${AT_OWNER_REPO}"
+AT_OWNER_REPO="${AT_OWNER_REPO:-${AT_OWNER}/${AT_REPO}}"
+AT_BASE_URL="${AT_BASE_URL:-https://github.com/${AT_OWNER_REPO}}"
 
 # ==============================================================================
 # Numeric constants  (used by more than one script)
@@ -35,8 +39,8 @@ AT_FAILURE_LIMIT="${AT_FAILURE_LIMIT:-30}"      # consecutive failures before st
 # ==============================================================================
 # Feature flags  (mirror the action.yml inputs where relevant)
 # ==============================================================================
-AT_CUTOFF_COMMIT="${CUTOFF_COMMIT:-}"           # ignore runs newer than this SHA
-AT_REUSE_DATA="${REUSE_DATA:-false}"            # skip re-downloading data if present
+AT_CUTOFF_COMMIT="${AT_CUTOFF_COMMIT:-${CUTOFF_COMMIT:-}}"           # ignore runs newer than this SHA
+AT_REUSE_DATA="${AT_REUSE_DATA:-${REUSE_DATA:-false}}"            # skip re-downloading data if present
 
 # ==============================================================================
 # Directory helpers  (thin wrappers around common.sh, adding mkdir + symlinks)

--- a/.github/actions/auto-triage/auto_triage/lib/github_api.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/github_api.sh
@@ -216,15 +216,16 @@ get_check_annotations() {
 
 # Download the full log zip for a workflow run into a target directory.
 # Extracts the zip and removes the temporary file.
+# Uses AT_OWNER_REPO from config (same as other helpers in this file).
 #
-#   download_run_logs "$owner" "$repo" "$run_id" "/tmp/logs"
+#   download_run_logs "$run_id" "/tmp/logs"
 #
 download_run_logs() {
-    local owner="$1" repo="$2" run_id="$3" dest="$4"
+    local run_id="$1" dest="$2"
     local tmp_zip
     tmp_zip="$(mktemp --suffix=.zip 2>/dev/null || mktemp)"
     mkdir -p "$dest"
-    gh api "repos/${owner}/${repo}/actions/runs/${run_id}/logs" > "$tmp_zip" 2>/dev/null || {
+    gh api "repos/${AT_OWNER_REPO}/actions/runs/${run_id}/logs" > "$tmp_zip" 2>/dev/null || {
         rm -f "$tmp_zip"
         return 1
     }

--- a/.github/actions/auto-triage/auto_triage/lib/github_api.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/github_api.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# github_api.sh - GitHub API wrapper functions for auto-triage
+#
+# Provides thin, consistent wrappers around `gh api` with:
+#   - Silent stderr by default (no noisy 404s in logs)
+#   - Configurable JSON fallback on failure
+#   - POST support with HTTP status inspection
+#   - Common endpoint helpers (workflows, runs, jobs, commits, PRs)
+#
+# Prerequisites: gh CLI authenticated, lib/common.sh and lib/config.sh sourced.
+#
+
+if [ -n "${_AUTO_TRIAGE_GITHUB_API_LOADED:-}" ]; then
+    return 0
+fi
+_AUTO_TRIAGE_GITHUB_API_LOADED=1
+
+# ==============================================================================
+# Low-level helpers
+# ==============================================================================
+
+# GET a GitHub API endpoint.  Returns the JSON body on success, or $fallback
+# (default "{}") on any error.
+#
+#   gh_api "repos/owner/repo/actions/runs/123" [fallback]
+#
+gh_api() {
+    local endpoint="$1"
+    local fallback="${2:-{\}}"
+    local result
+    if result=$(gh api "$endpoint" 2>/dev/null); then
+        echo "$result"
+    else
+        echo "$fallback"
+    fi
+}
+
+# GET with a jq selector applied server-side (--jq).
+#
+#   gh_api_jq "repos/o/r/commits/SHA" '.author.login // empty' ""
+#
+gh_api_jq() {
+    local endpoint="$1" jq_expr="$2" fallback="${3:-}"
+    gh api "$endpoint" --jq "$jq_expr" 2>/dev/null || echo "$fallback"
+}
+
+# POST to a GitHub API endpoint.  Prints the full response (headers + body,
+# via -i) so callers can inspect the HTTP status code.  Returns "API_ERROR"
+# on complete failure.
+#
+#   response=$(gh_api_post "repos/o/r/actions/jobs/123/rerun")
+#   status=$(echo "$response" | head -1 | awk '{print $2}')
+#
+gh_api_post() {
+    local endpoint="$1"
+    gh api --method POST "$endpoint" -i 2>&1 || echo "API_ERROR"
+}
+
+# ==============================================================================
+# Workflow helpers
+# ==============================================================================
+
+# Resolve a workflow filename (e.g. "ci.yml") to its numeric ID.
+# Tries both .yml and .yaml extensions.  Prints the ID or "" on failure.
+#
+#   wf_id=$(get_workflow_id "ci.yml")
+#
+get_workflow_id() {
+    local name="$1"
+    local raw id
+
+    # Try the name as given
+    raw=$(gh_api "repos/${AT_OWNER_REPO}/actions/workflows/${name}" "")
+    id=$(echo "$raw" | jq -r '.id // empty' 2>/dev/null)
+    if [ -n "$id" ]; then echo "$id"; return 0; fi
+
+    # Try swapping .yml <-> .yaml
+    local alt
+    case "$name" in
+        *.yml)  alt="${name%.yml}.yaml" ;;
+        *.yaml) alt="${name%.yaml}.yml" ;;
+        *)      return 1 ;;
+    esac
+    raw=$(gh_api "repos/${AT_OWNER_REPO}/actions/workflows/${alt}" "")
+    id=$(echo "$raw" | jq -r '.id // empty' 2>/dev/null)
+    if [ -n "$id" ]; then echo "$id"; return 0; fi
+
+    return 1
+}
+
+# Fetch one page of workflow runs.
+#
+#   page_json=$(get_workflow_runs "$wf_id" 1)
+#
+get_workflow_runs() {
+    local wf_id="$1" page="${2:-1}"
+    gh_api "repos/${AT_OWNER_REPO}/actions/workflows/${wf_id}/runs?branch=main&per_page=${AT_PER_PAGE}&page=${page}"
+}
+
+# ==============================================================================
+# Job / run helpers
+# ==============================================================================
+
+# Get jobs for a run (optionally a specific attempt).
+#
+#   jobs_json=$(get_jobs_for_run "$run_id")
+#   jobs_json=$(get_jobs_for_run "$run_id" 3)
+#
+get_jobs_for_run() {
+    local run_id="$1" attempt="${2:-}"
+    if [ -n "$attempt" ]; then
+        gh_api "repos/${AT_OWNER_REPO}/actions/runs/${run_id}/attempts/${attempt}/jobs?per_page=${AT_PER_PAGE}"
+    else
+        gh_api "repos/${AT_OWNER_REPO}/actions/runs/${run_id}/jobs?per_page=${AT_PER_PAGE}"
+    fi
+}
+
+# Get metadata for a single job by ID.
+#
+#   job_json=$(get_job_info "$job_id")
+#
+get_job_info() {
+    gh_api "repos/${AT_OWNER_REPO}/actions/jobs/$1"
+}
+
+# Get metadata for a workflow run.
+#
+#   run_json=$(get_run_info "$run_id")
+#
+get_run_info() {
+    gh_api "repos/${AT_OWNER_REPO}/actions/runs/$1"
+}
+
+# ==============================================================================
+# Commit / PR helpers
+# ==============================================================================
+
+# Get commit metadata (author, message, etc.).
+#
+#   commit_json=$(get_commit_info "abc123")
+#
+get_commit_info() {
+    gh_api "repos/${AT_OWNER_REPO}/commits/$1"
+}
+
+# Get the author login for a commit, or "" if unavailable.
+#
+#   author=$(get_commit_author "abc123")
+#
+get_commit_author() {
+    gh_api_jq "repos/${AT_OWNER_REPO}/commits/$1" '.author.login // empty' ""
+}
+
+# Find the PR number associated with a commit, or "" if none.
+#
+#   pr_num=$(get_pr_for_commit "abc123")
+#
+get_pr_for_commit() {
+    gh api -H "Accept: application/vnd.github.groot-preview+json" \
+        "repos/${AT_OWNER_REPO}/commits/$1/pulls" \
+        --jq '.[0].number // empty' 2>/dev/null || echo ""
+}
+
+# Get approved reviewers for a PR (unique logins, one per line).
+#
+#   reviewers=$(get_pr_approvers 42)
+#
+get_pr_approvers() {
+    local pr_number="$1"
+    gh api "repos/${AT_OWNER_REPO}/pulls/${pr_number}/reviews" \
+        --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique[]' \
+        2>/dev/null || echo ""
+}
+
+# Get full PR metadata.
+#
+#   pr_json=$(get_pr_info 42)
+#
+get_pr_info() {
+    gh_api "repos/${AT_OWNER_REPO}/pulls/$1"
+}
+
+# ==============================================================================
+# Annotation helpers
+# ==============================================================================
+
+# Fetch check-run annotations (paginated).  Returns a JSON array.
+#
+#   annotations=$(get_check_annotations "$check_run_id")
+#
+get_check_annotations() {
+    local check_id="$1"
+    local page=1 all="[]" batch
+
+    while true; do
+        batch=$(gh_api "repos/${AT_OWNER_REPO}/check-runs/${check_id}/annotations?per_page=100&page=${page}" "[]")
+        local count
+        count=$(echo "$batch" | jq 'length' 2>/dev/null || echo 0)
+        [ "$count" -gt 0 ] || break
+        all=$(echo "$all" "$batch" | jq -s '.[0] + .[1]' 2>/dev/null || echo "$all")
+        page=$((page + 1))
+    done
+    echo "$all"
+}
+
+# ==============================================================================
+# Log download helper
+# ==============================================================================
+
+# Download the full log zip for a workflow run into a target directory.
+# Extracts the zip and removes the temporary file.
+#
+#   download_run_logs "$owner" "$repo" "$run_id" "/tmp/logs"
+#
+download_run_logs() {
+    local owner="$1" repo="$2" run_id="$3" dest="$4"
+    local tmp_zip
+    tmp_zip="$(mktemp --suffix=.zip 2>/dev/null || mktemp)"
+    mkdir -p "$dest"
+    gh api "repos/${owner}/${repo}/actions/runs/${run_id}/logs" > "$tmp_zip" 2>/dev/null || {
+        rm -f "$tmp_zip"
+        return 1
+    }
+    unzip -oq "$tmp_zip" -d "$dest" 2>/dev/null
+    rm -f "$tmp_zip"
+}

--- a/.github/actions/auto-triage/auto_triage/lib/github_api.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/github_api.sh
@@ -8,13 +8,19 @@
 #   - POST support with HTTP status inspection
 #   - Common endpoint helpers (workflows, runs, jobs, commits, PRs)
 #
-# Prerequisites: gh CLI authenticated, lib/common.sh and lib/config.sh sourced.
+# Prerequisites: gh CLI authenticated.
+# Usage: source this file (it pulls in config.sh, which pulls in common.sh).
 #
 
 if [ -n "${_AUTO_TRIAGE_GITHUB_API_LOADED:-}" ]; then
     return 0
 fi
 _AUTO_TRIAGE_GITHUB_API_LOADED=1
+
+# github_api.sh depends on config.sh (AT_OWNER_REPO, AT_PER_PAGE, etc.).
+_GITHUB_API_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "$_GITHUB_API_LIB_DIR/config.sh"
 
 # ==============================================================================
 # Low-level helpers

--- a/.github/actions/auto-triage/auto_triage/lib/validation.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/validation.sh
@@ -5,13 +5,19 @@
 # Provides reusable checks that are currently scattered (and duplicated)
 # across find_boundaries.sh, download_*.sh, get_logs.sh, etc.
 #
-# Prerequisites: lib/common.sh sourced (for die/warn).
+# Prerequisites: none (sources common.sh for die/warn).
+# Usage: source this file (it pulls in common.sh automatically).
 #
 
 if [ -n "${_AUTO_TRIAGE_VALIDATION_LOADED:-}" ]; then
     return 0
 fi
 _AUTO_TRIAGE_VALIDATION_LOADED=1
+
+# validation.sh depends on common.sh (die, warn).
+_VALIDATION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$_VALIDATION_LIB_DIR/common.sh"
 
 # ==============================================================================
 # Commit SHA validation

--- a/.github/actions/auto-triage/auto_triage/lib/validation.sh
+++ b/.github/actions/auto-triage/auto_triage/lib/validation.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# validation.sh - Input and output validation helpers for auto-triage
+#
+# Provides reusable checks that are currently scattered (and duplicated)
+# across find_boundaries.sh, download_*.sh, get_logs.sh, etc.
+#
+# Prerequisites: lib/common.sh sourced (for die/warn).
+#
+
+if [ -n "${_AUTO_TRIAGE_VALIDATION_LOADED:-}" ]; then
+    return 0
+fi
+_AUTO_TRIAGE_VALIDATION_LOADED=1
+
+# ==============================================================================
+# Commit SHA validation
+# ==============================================================================
+
+# Verify that a string looks like a full or abbreviated commit SHA and that
+# git recognises it in the current repository.  Dies on failure.
+#
+#   validate_commit_sha "$sha"
+#   validate_commit_sha "$sha" "Start commit"
+#
+validate_commit_sha() {
+    local sha="$1" label="${2:-Commit}"
+    if [ -z "$sha" ]; then
+        die "$label SHA is empty"
+    fi
+    if ! git rev-parse --verify "$sha" >/dev/null 2>&1; then
+        die "$label '$sha' not found in repository"
+    fi
+}
+
+# Lighter check: does the string look like a hex SHA (7-40 chars)?
+# Returns 0/1, does not die.
+#
+#   if is_valid_sha_format "$input"; then ...
+#
+is_valid_sha_format() {
+    [[ "$1" =~ ^[0-9a-f]{7,40}$ ]]
+}
+
+# ==============================================================================
+# GitHub job URL parsing
+# ==============================================================================
+
+# Parse a GitHub Actions job URL into its components.
+# Sets the caller's variables: _owner, _repo, _run_id, _job_id.
+# Returns 1 if the URL doesn't match the expected pattern.
+#
+#   if parse_job_url "$url"; then
+#       echo "$_owner $_repo $_run_id $_job_id"
+#   fi
+#
+parse_job_url() {
+    local url="$1"
+    if [[ "$url" =~ github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+)/job/([0-9]+) ]]; then
+        _owner="${BASH_REMATCH[1]}"
+        _repo="${BASH_REMATCH[2]}"
+        _run_id="${BASH_REMATCH[3]}"
+        _job_id="${BASH_REMATCH[4]}"
+        return 0
+    fi
+    return 1
+}
+
+# ==============================================================================
+# JSON file validation
+# ==============================================================================
+
+# Assert that a file exists, is non-empty, and contains valid JSON.
+# Dies on failure unless quiet=true (returns 1 instead).
+#
+#   validate_json_file "auto_triage/data/commit_info.json"
+#   validate_json_file "$f" "quiet"   # returns 1 instead of dying
+#
+validate_json_file() {
+    local file="$1" quiet="${2:-}"
+    local _die_or_return
+    if [ "$quiet" = "quiet" ]; then
+        _die_or_return() { return 1; }
+    else
+        _die_or_return() { die "$@"; }
+    fi
+
+    if [ ! -f "$file" ]; then
+        _die_or_return "JSON file not found: $file"
+        return $?
+    fi
+    if [ ! -s "$file" ]; then
+        _die_or_return "JSON file is empty: $file"
+        return $?
+    fi
+    if ! jq empty "$file" 2>/dev/null; then
+        _die_or_return "Invalid JSON in $file"
+        return $?
+    fi
+    return 0
+}
+
+# ==============================================================================
+# Path / directory validation
+# ==============================================================================
+
+# Ensure one or more directories exist; create them if they don't.
+#
+#   ensure_dirs "$DATA_DIR" "$LOGS_DIR"
+#
+ensure_dirs() {
+    local dir
+    for dir in "$@"; do
+        mkdir -p "$dir"
+    done
+}

--- a/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
@@ -84,7 +84,7 @@ assert_fails "require_env (unset)" require_env __T_REQ
 # -- JSON helpers (skip if jq absent) ----------------------------------------
 if command -v jq >/dev/null 2>&1; then
     _tmp=$(mktemp)
-    echo '{"name":"triage","count":42}' > "$_tmp"
+    echo '{"name":"triage","count":42,"null":null}' > "$_tmp"
 
     assert_eq "json_get existing key"  "$(json_get .name  "$_tmp" x)"      "triage"
     assert_eq "json_get missing key"   "$(json_get .nope  "$_tmp" dflt)"   "dflt"

--- a/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
@@ -9,40 +9,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
 
+source "$SCRIPT_DIR/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$LIB_DIR/common.sh"
-
-# -----------------------------------------------------------------------------
-# Minimal test harness
-# -----------------------------------------------------------------------------
-_pass=0 _fail=0
-
-assert() {                       # assert "description" <command...>
-    local desc="$1"; shift
-    if "$@" 2>/dev/null; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc"; _fail=$((_fail + 1))
-    fi
-}
-
-assert_eq() {                    # assert_eq "description" "actual" "expected"
-    local desc="$1" actual="$2" expected="$3"
-    if [ "$actual" = "$expected" ]; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
-    fi
-}
-
-assert_fails() {                 # assert_fails "description" <command...>
-    local desc="$1"; shift
-    if ! ("$@" 2>/dev/null); then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
-    fi
-}
 
 echo "=== lib/common.sh ==="
 
@@ -98,6 +67,4 @@ else
 fi
 
 # -- summary ------------------------------------------------------------------
-echo ""
-echo "=== $_pass passed, $_fail failed ==="
-[ "$_fail" -eq 0 ]
+test_summary

--- a/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Basic smoke tests for lib/common.sh
+# Run from auto_triage/ directory: ./tests/lib/common_test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUTO_TRIAGE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB_DIR="$AUTO_TRIAGE_DIR/lib"
+
+export AUTO_TRIAGE_ROOT="$AUTO_TRIAGE_DIR"
+source "$LIB_DIR/common.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "  OK: $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo "  FAIL: $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+echo "=== lib/common.sh smoke tests ==="
+
+run_test "root is set" test -n "${AUTO_TRIAGE_ROOT:-}"
+
+run_test "get_data_dir" test -n "$(get_data_dir)" -a "$(get_data_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/data"
+
+run_test "get_output_dir" test -n "$(get_output_dir)" -a "$(get_output_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/output"
+
+run_test "get_logs_dir" test -n "$(get_logs_dir)" -a "$(get_logs_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/logs"
+
+run_test "get_data_dir with explicit root" test "$(get_data_dir /tmp/foo)" = "/tmp/foo/auto_triage/data"
+
+run_test "log functions" eval 'log_info x >/dev/null && log_error x 2>/dev/null && log_warn x 2>/dev/null && log_success x >/dev/null'
+
+run_test "check_command exists" check_command bash
+
+run_test "check_command missing" eval '! (check_command __nonexistent_cmd_xyz_xyz 2>/dev/null)'
+
+unset __TEST_UNSET_VAR 2>/dev/null || true
+run_test "get_env_with_default unset" test "$(get_env_with_default __TEST_UNSET_VAR "default")" = "default"
+
+export __TEST_SET_VAR="actual"
+run_test "get_env_with_default set" test "$(get_env_with_default __TEST_SET_VAR "default")" = "actual"
+unset __TEST_SET_VAR
+
+# die exits with 1 (run in subshell since die exits)
+if ( die "test" 2>/dev/null ); then
+    echo "  FAIL: die should exit 1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+    [ $? -eq 1 ] && { echo "  OK: die exits with 1"; TESTS_PASSED=$((TESTS_PASSED + 1)); } || { echo "  FAIL: die exit code"; TESTS_FAILED=$((TESTS_FAILED + 1)); }
+fi
+
+if command -v jq >/dev/null 2>&1; then
+    TMP_JSON=$(mktemp)
+    echo '{"key":"value"}' > "$TMP_JSON"
+    run_test "json_get" test "$(json_get .key "$TMP_JSON" "x")" = "value"
+    run_test "json_get default" test "$(json_get .missing "$TMP_JSON" "fallback")" = "fallback"
+    rm -f "$TMP_JSON"
+else
+    echo "  SKIP: json tests (jq not installed)"
+fi
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+
+[ $TESTS_FAILED -eq 0 ]

--- a/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/common_test.sh
@@ -1,79 +1,103 @@
 #!/bin/bash
 #
-# Basic smoke tests for lib/common.sh
-# Run from auto_triage/ directory: ./tests/lib/common_test.sh
+# Smoke tests for lib/common.sh
+# Run:  cd .github/actions/auto-triage/auto_triage && ./tests/lib/common_test.sh
 #
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-AUTO_TRIAGE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-LIB_DIR="$AUTO_TRIAGE_DIR/lib"
+LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
 
-export AUTO_TRIAGE_ROOT="$AUTO_TRIAGE_DIR"
+export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$LIB_DIR/common.sh"
 
-TESTS_PASSED=0
-TESTS_FAILED=0
+# -----------------------------------------------------------------------------
+# Minimal test harness
+# -----------------------------------------------------------------------------
+_pass=0 _fail=0
 
-run_test() {
-    local name="$1"
-    shift
-    if "$@"; then
-        echo "  OK: $name"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
+assert() {                       # assert "description" <command...>
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
     else
-        echo "  FAIL: $name"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
+        echo "  FAIL  $desc"; _fail=$((_fail + 1))
     fi
 }
 
-echo "=== lib/common.sh smoke tests ==="
+assert_eq() {                    # assert_eq "description" "actual" "expected"
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
+    fi
+}
 
-run_test "root is set" test -n "${AUTO_TRIAGE_ROOT:-}"
+assert_fails() {                 # assert_fails "description" <command...>
+    local desc="$1"; shift
+    if ! ("$@" 2>/dev/null); then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
+    fi
+}
 
-run_test "get_data_dir" test -n "$(get_data_dir)" -a "$(get_data_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/data"
+echo "=== lib/common.sh ==="
 
-run_test "get_output_dir" test -n "$(get_output_dir)" -a "$(get_output_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/output"
+# -- root detection -----------------------------------------------------------
+assert "AUTO_TRIAGE_ROOT is set" test -n "$AUTO_TRIAGE_ROOT"
 
-run_test "get_logs_dir" test -n "$(get_logs_dir)" -a "$(get_logs_dir)" = "${AUTO_TRIAGE_ROOT}/auto_triage/logs"
+# -- path helpers -------------------------------------------------------------
+assert_eq "get_data_dir"            "$(get_data_dir)"            "$AUTO_TRIAGE_ROOT/auto_triage/data"
+assert_eq "get_output_dir"          "$(get_output_dir)"          "$AUTO_TRIAGE_ROOT/auto_triage/output"
+assert_eq "get_logs_dir"            "$(get_logs_dir)"            "$AUTO_TRIAGE_ROOT/auto_triage/logs"
+assert_eq "get_data_dir custom root" "$(get_data_dir /tmp/foo)"  "/tmp/foo/auto_triage/data"
 
-run_test "get_data_dir with explicit root" test "$(get_data_dir /tmp/foo)" = "/tmp/foo/auto_triage/data"
+# -- logging (just verifying no crash) ----------------------------------------
+assert "log_info"    eval 'log_info    "msg" >/dev/null'
+assert "log_success" eval 'log_success "msg" >/dev/null'
+assert "log_warn"    eval 'log_warn    "msg" 2>/dev/null'
+assert "log_error"   eval 'log_error   "msg" 2>/dev/null'
 
-run_test "log functions" eval 'log_info x >/dev/null && log_error x 2>/dev/null && log_warn x 2>/dev/null && log_success x >/dev/null'
+# -- error handling -----------------------------------------------------------
+assert       "check_command (exists)"  check_command bash
+assert_fails "check_command (missing)" check_command __no_such_cmd_abc123
+assert_fails "die exits"               die "deliberate"
 
-run_test "check_command exists" check_command bash
+assert "warn does not exit" eval 'warn "harmless" 2>/dev/null; true'
 
-run_test "check_command missing" eval '! (check_command __nonexistent_cmd_xyz_xyz 2>/dev/null)'
+# -- env helpers --------------------------------------------------------------
+unset __T_UNSET 2>/dev/null || true
+assert_eq "get_env_with_default (unset)" "$(get_env_with_default __T_UNSET fallback)" "fallback"
 
-unset __TEST_UNSET_VAR 2>/dev/null || true
-run_test "get_env_with_default unset" test "$(get_env_with_default __TEST_UNSET_VAR "default")" = "default"
+export __T_SET="hello"
+assert_eq "get_env_with_default (set)"   "$(get_env_with_default __T_SET fallback)"   "hello"
+unset __T_SET
 
-export __TEST_SET_VAR="actual"
-run_test "get_env_with_default set" test "$(get_env_with_default __TEST_SET_VAR "default")" = "actual"
-unset __TEST_SET_VAR
+export __T_REQ="ok"
+assert "require_env (set)"   eval 'require_env __T_REQ'
+unset __T_REQ
+assert_fails "require_env (unset)" require_env __T_REQ
 
-# die exits with 1 (run in subshell since die exits)
-if ( die "test" 2>/dev/null ); then
-    echo "  FAIL: die should exit 1"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-else
-    [ $? -eq 1 ] && { echo "  OK: die exits with 1"; TESTS_PASSED=$((TESTS_PASSED + 1)); } || { echo "  FAIL: die exit code"; TESTS_FAILED=$((TESTS_FAILED + 1)); }
-fi
-
+# -- JSON helpers (skip if jq absent) ----------------------------------------
 if command -v jq >/dev/null 2>&1; then
-    TMP_JSON=$(mktemp)
-    echo '{"key":"value"}' > "$TMP_JSON"
-    run_test "json_get" test "$(json_get .key "$TMP_JSON" "x")" = "value"
-    run_test "json_get default" test "$(json_get .missing "$TMP_JSON" "fallback")" = "fallback"
-    rm -f "$TMP_JSON"
+    _tmp=$(mktemp)
+    echo '{"name":"triage","count":42}' > "$_tmp"
+
+    assert_eq "json_get existing key"  "$(json_get .name  "$_tmp" x)"      "triage"
+    assert_eq "json_get missing key"   "$(json_get .nope  "$_tmp" dflt)"   "dflt"
+    assert_eq "json_get null key"      "$(json_get .null  "$_tmp" none)"   "none"
+    assert_eq "jq_safe"                "$(jq_safe -r .name "$_tmp")"       "triage"
+    assert_fails "jq_safe missing file" jq_safe -r .name "/no/such/file.json"
+
+    rm -f "$_tmp"
 else
-    echo "  SKIP: json tests (jq not installed)"
+    echo "  SKIP  json tests (jq not installed)"
 fi
 
+# -- summary ------------------------------------------------------------------
 echo ""
-echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
-
-[ $TESTS_FAILED -eq 0 ]
+echo "=== $_pass passed, $_fail failed ==="
+[ "$_fail" -eq 0 ]

--- a/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
@@ -10,7 +10,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
 
 export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-source "$LIB_DIR/common.sh"
 source "$LIB_DIR/config.sh"
 
 # -- test harness (same helpers as common_test.sh) ----------------------------
@@ -54,11 +53,14 @@ assert_eq "AT_REUSE_DATA default"   "$AT_REUSE_DATA"    "false"
 
 # -- env override works --------------------------------------------------------
 (
-    export AT_OWNER="myorg" AT_REPO="myrepo" AT_BATCH_SIZE="5"
+    unset AT_OWNER_REPO AT_BASE_URL
+    export AT_OWNER="myorg" AT_REPO="myrepo" AT_BATCH_SIZE="5" AT_CUTOFF_COMMIT="deadbeef" AT_REUSE_DATA="true"
     # Re-source to pick up overrides (reset guard first)
     unset _AUTO_TRIAGE_CONFIG_LOADED
     source "$LIB_DIR/config.sh"
-    [ "$AT_OWNER" = "myorg" ] && [ "$AT_REPO" = "myrepo" ] && [ "$AT_BATCH_SIZE" = "5" ]
+    [ "$AT_OWNER" = "myorg" ] && [ "$AT_REPO" = "myrepo" ] && [ "$AT_BATCH_SIZE" = "5" ] \
+      && [ "$AT_OWNER_REPO" = "myorg/myrepo" ] && [ "$AT_BASE_URL" = "https://github.com/myorg/myrepo" ] \
+      && [ "$AT_CUTOFF_COMMIT" = "deadbeef" ] && [ "$AT_REUSE_DATA" = "true" ]
 ) && { echo "  PASS  env overrides"; _pass=$((_pass + 1)); } \
   || { echo "  FAIL  env overrides"; _fail=$((_fail + 1)); }
 

--- a/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Smoke tests for lib/config.sh
+# Run:  cd .github/actions/auto-triage/auto_triage && ./tests/lib/config_test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
+
+export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$LIB_DIR/common.sh"
+source "$LIB_DIR/config.sh"
+
+# -- test harness (same helpers as common_test.sh) ----------------------------
+_pass=0 _fail=0
+
+assert_eq() {
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
+    fi
+}
+
+assert() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc"; _fail=$((_fail + 1))
+    fi
+}
+
+echo "=== lib/config.sh ==="
+
+# -- repository defaults -------------------------------------------------------
+assert_eq "AT_OWNER default"      "$AT_OWNER"      "tenstorrent"
+assert_eq "AT_REPO default"       "$AT_REPO"       "tt-metal"
+assert_eq "AT_OWNER_REPO"         "$AT_OWNER_REPO" "tenstorrent/tt-metal"
+assert_eq "AT_BASE_URL"           "$AT_BASE_URL"    "https://github.com/tenstorrent/tt-metal"
+
+# -- numeric constants ---------------------------------------------------------
+assert_eq "AT_BATCH_SIZE"         "$AT_BATCH_SIZE"     "10"
+assert_eq "AT_MAX_BATCHES"        "$AT_MAX_BATCHES"    "100"
+assert_eq "AT_PER_PAGE"           "$AT_PER_PAGE"       "100"
+assert_eq "AT_FAILURE_LIMIT"      "$AT_FAILURE_LIMIT"  "30"
+
+# -- feature flags -------------------------------------------------------------
+assert_eq "AT_CUTOFF_COMMIT empty"  "$AT_CUTOFF_COMMIT" ""
+assert_eq "AT_REUSE_DATA default"   "$AT_REUSE_DATA"    "false"
+
+# -- env override works --------------------------------------------------------
+(
+    export AT_OWNER="myorg" AT_REPO="myrepo" AT_BATCH_SIZE="5"
+    # Re-source to pick up overrides (reset guard first)
+    unset _AUTO_TRIAGE_CONFIG_LOADED
+    source "$LIB_DIR/config.sh"
+    [ "$AT_OWNER" = "myorg" ] && [ "$AT_REPO" = "myrepo" ] && [ "$AT_BATCH_SIZE" = "5" ]
+) && { echo "  PASS  env overrides"; _pass=$((_pass + 1)); } \
+  || { echo "  FAIL  env overrides"; _fail=$((_fail + 1)); }
+
+# -- setup_triage_dirs ---------------------------------------------------------
+TMP_ROOT=$(mktemp -d)
+setup_triage_dirs "$TMP_ROOT"
+
+assert "data dir created"   test -d "$TMP_ROOT/auto_triage/data"
+assert "logs dir created"   test -d "$TMP_ROOT/auto_triage/logs"
+assert "output dir created" test -d "$TMP_ROOT/auto_triage/output"
+assert "data symlink"       test -L "$TMP_ROOT/data"
+assert "logs symlink"       test -L "$TMP_ROOT/logs"
+assert "output symlink"     test -L "$TMP_ROOT/output"
+
+rm -rf "$TMP_ROOT"
+
+# -- double-source guard -------------------------------------------------------
+(
+    source "$LIB_DIR/config.sh"   # should be a no-op (already loaded)
+    true
+) && { echo "  PASS  double-source guard"; _pass=$((_pass + 1)); } \
+  || { echo "  FAIL  double-source guard"; _fail=$((_fail + 1)); }
+
+echo ""
+echo "=== $_pass passed, $_fail failed ==="
+[ "$_fail" -eq 0 ]

--- a/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/config_test.sh
@@ -9,29 +9,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
 
+source "$SCRIPT_DIR/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 source "$LIB_DIR/config.sh"
-
-# -- test harness (same helpers as common_test.sh) ----------------------------
-_pass=0 _fail=0
-
-assert_eq() {
-    local desc="$1" actual="$2" expected="$3"
-    if [ "$actual" = "$expected" ]; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
-    fi
-}
-
-assert() {
-    local desc="$1"; shift
-    if "$@" 2>/dev/null; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc"; _fail=$((_fail + 1))
-    fi
-}
 
 echo "=== lib/config.sh ==="
 
@@ -84,6 +64,4 @@ rm -rf "$TMP_ROOT"
 ) && { echo "  PASS  double-source guard"; _pass=$((_pass + 1)); } \
   || { echo "  FAIL  double-source guard"; _fail=$((_fail + 1)); }
 
-echo ""
-echo "=== $_pass passed, $_fail failed ==="
-[ "$_fail" -eq 0 ]
+test_summary

--- a/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
@@ -14,39 +14,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIB_DIR="$ROOT_DIR/lib"
 
+source "$SCRIPT_DIR/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$ROOT_DIR"
-source "$LIB_DIR/common.sh"
-source "$LIB_DIR/config.sh"
-
-# -- test harness -------------------------------------------------------------
-_pass=0 _fail=0
-
-assert_eq() {
-    local desc="$1" actual="$2" expected="$3"
-    if [ "$actual" = "$expected" ]; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
-    fi
-}
-
-assert() {
-    local desc="$1"; shift
-    if "$@" 2>/dev/null; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc"; _fail=$((_fail + 1))
-    fi
-}
-
-assert_fails() {
-    local desc="$1"; shift
-    if ! ("$@" 2>/dev/null); then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
-    fi
-}
+source "$LIB_DIR/github_api.sh"
 
 # -- create mock gh CLI --------------------------------------------------------
 MOCK_DIR=$(mktemp -d)
@@ -152,6 +122,4 @@ assert_eq "get_check_annotations empty" "$anns" "[]"
 # -- cleanup -------------------------------------------------------------------
 rm -rf "$MOCK_DIR"
 
-echo ""
-echo "=== $_pass passed, $_fail failed ==="
-[ "$_fail" -eq 0 ]
+test_summary

--- a/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Smoke tests for lib/github_api.sh
+#
+# Tests the structural parts (function existence, arg handling) and uses a
+# mock `gh` script for API-dependent functions so we don't need real auth.
+#
+# Run:  cd .github/actions/auto-triage/auto_triage && ./tests/lib/github_api_test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB_DIR="$ROOT_DIR/lib"
+
+export AUTO_TRIAGE_ROOT="$ROOT_DIR"
+source "$LIB_DIR/common.sh"
+source "$LIB_DIR/config.sh"
+
+# -- test harness -------------------------------------------------------------
+_pass=0 _fail=0
+
+assert_eq() {
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
+    fi
+}
+
+assert() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc"; _fail=$((_fail + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"; shift
+    if ! ("$@" 2>/dev/null); then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
+    fi
+}
+
+# -- create mock gh CLI --------------------------------------------------------
+MOCK_DIR=$(mktemp -d)
+cat > "$MOCK_DIR/gh" <<'MOCKSCRIPT'
+#!/bin/bash
+# Minimal mock: returns canned JSON for known endpoints, error for unknown.
+endpoint=""
+method="GET"
+jq_expr=""
+include_headers=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        api)        shift; continue ;;
+        --method)   method="$2"; shift 2; continue ;;
+        --jq)       jq_expr="$2"; shift 2; continue ;;
+        -H)         shift 2; continue ;;
+        -i)         include_headers=true; shift; continue ;;
+        *)          endpoint="$1"; shift ;;
+    esac
+done
+
+case "$endpoint" in
+    repos/tenstorrent/tt-metal/actions/workflows/ci.yml)
+        echo '{"id":12345,"name":"ci"}' ;;
+    repos/tenstorrent/tt-metal/actions/workflows/ci.yaml)
+        echo '{"id":12345,"name":"ci"}' ;;
+    repos/tenstorrent/tt-metal/actions/workflows/nope.yml)
+        echo '{"message":"Not Found"}' ; exit 1 ;;
+    repos/tenstorrent/tt-metal/commits/abc123)
+        json='{"sha":"abc123","author":{"login":"testuser"}}'
+        if [ -n "$jq_expr" ]; then
+            echo "$json" | jq -r "$jq_expr" 2>/dev/null
+        else
+            echo "$json"
+        fi ;;
+    repos/tenstorrent/tt-metal/actions/jobs/999)
+        echo '{"id":999,"name":"test-job","status":"completed"}' ;;
+    repos/tenstorrent/tt-metal/actions/runs/555)
+        echo '{"id":555,"status":"completed","conclusion":"failure"}' ;;
+    repos/tenstorrent/tt-metal/actions/runs/555/jobs*)
+        echo '{"jobs":[{"id":999,"name":"test-job"}]}' ;;
+    repos/tenstorrent/tt-metal/check-runs/777/annotations*)
+        echo '[]' ;;
+    *)
+        if $include_headers; then
+            echo "HTTP/2 201"
+            echo '{"message":"ok"}'
+        else
+            echo '{"message":"Not Found"}'
+            exit 1
+        fi ;;
+esac
+MOCKSCRIPT
+chmod +x "$MOCK_DIR/gh"
+export PATH="$MOCK_DIR:$PATH"
+
+# Now source the API lib (it will find our mock gh)
+source "$LIB_DIR/github_api.sh"
+
+echo "=== lib/github_api.sh ==="
+
+# -- gh_api / gh_api_jq -------------------------------------------------------
+result=$(gh_api "repos/tenstorrent/tt-metal/commits/abc123")
+assert_eq "gh_api returns JSON" "$(echo "$result" | jq -r .sha)" "abc123"
+
+result=$(gh_api "repos/nonexistent/endpoint/404" "fallback_val")
+assert_eq "gh_api fallback on error" "$result" "fallback_val"
+
+result=$(gh_api_jq "repos/tenstorrent/tt-metal/commits/abc123" '.author.login // empty' "")
+assert_eq "gh_api_jq extracts field" "$result" "testuser"
+
+# -- get_workflow_id -----------------------------------------------------------
+wf_id=$(get_workflow_id "ci.yml")
+assert_eq "get_workflow_id" "$wf_id" "12345"
+
+assert_fails "get_workflow_id unknown" get_workflow_id "nope.yml"
+
+# -- get_job_info / get_run_info -----------------------------------------------
+job=$(get_job_info 999)
+assert_eq "get_job_info" "$(echo "$job" | jq -r .name)" "test-job"
+
+run=$(get_run_info 555)
+assert_eq "get_run_info" "$(echo "$run" | jq -r .conclusion)" "failure"
+
+# -- get_jobs_for_run ----------------------------------------------------------
+jobs=$(get_jobs_for_run 555)
+assert_eq "get_jobs_for_run" "$(echo "$jobs" | jq -r '.jobs[0].name')" "test-job"
+
+# -- get_commit_author ---------------------------------------------------------
+author=$(get_commit_author "abc123")
+assert_eq "get_commit_author" "$author" "testuser"
+
+# -- gh_api_post ---------------------------------------------------------------
+resp=$(gh_api_post "repos/tenstorrent/tt-metal/actions/jobs/123/rerun")
+status=$(echo "$resp" | head -1 | awk '{print $2}')
+assert_eq "gh_api_post status" "$status" "201"
+
+# -- get_check_annotations (empty) --------------------------------------------
+anns=$(get_check_annotations 777)
+assert_eq "get_check_annotations empty" "$anns" "[]"
+
+# -- cleanup -------------------------------------------------------------------
+rm -rf "$MOCK_DIR"
+
+echo ""
+echo "=== $_pass passed, $_fail failed ==="
+[ "$_fail" -eq 0 ]

--- a/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
@@ -16,7 +16,6 @@ LIB_DIR="$ROOT_DIR/lib"
 
 source "$SCRIPT_DIR/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$ROOT_DIR"
-source "$LIB_DIR/github_api.sh"
 
 # -- create mock gh CLI --------------------------------------------------------
 MOCK_DIR=$(mktemp -d)

--- a/.github/actions/auto-triage/auto_triage/tests/lib/test_harness.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/test_harness.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Shared test harness for lib tests. Source from common_test.sh, config_test.sh, etc.
+# Provides: assert, assert_eq, assert_fails, test_summary.
+# Initializes _pass and _fail.
+#
+
+_pass=0 _fail=0
+
+assert() {                       # assert "description" <command...>
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc"; _fail=$((_fail + 1))
+    fi
+}
+
+assert_eq() {                    # assert_eq "description" "actual" "expected"
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
+    fi
+}
+
+assert_fails() {                 # assert_fails "description" <command...>
+    local desc="$1"; shift
+    if ! ("$@" 2>/dev/null); then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
+    fi
+}
+
+test_summary() {
+    echo ""
+    echo "=== $_pass passed, $_fail failed ==="
+    [ "$_fail" -eq 0 ]
+}

--- a/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Smoke tests for lib/validation.sh
+# Run:  cd .github/actions/auto-triage/auto_triage && ./tests/lib/validation_test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
+
+export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$LIB_DIR/common.sh"
+source "$LIB_DIR/validation.sh"
+
+# -- test harness -------------------------------------------------------------
+_pass=0 _fail=0
+
+assert_eq() {
+    local desc="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
+    fi
+}
+
+assert() {
+    local desc="$1"; shift
+    if "$@" 2>/dev/null; then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc"; _fail=$((_fail + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"; shift
+    if ! ("$@" 2>/dev/null); then
+        echo "  PASS  $desc"; _pass=$((_pass + 1))
+    else
+        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
+    fi
+}
+
+echo "=== lib/validation.sh ==="
+
+# -- is_valid_sha_format -------------------------------------------------------
+assert "sha format: full 40-char"   is_valid_sha_format "abc123def456abc123def456abc123def456abc1"
+assert "sha format: short 7-char"   is_valid_sha_format "abc123d"
+assert_fails "sha format: too short (6)" eval 'is_valid_sha_format "abc123"'
+assert_fails "sha format: uppercase"     eval 'is_valid_sha_format "ABC123DEF"'
+assert_fails "sha format: non-hex"       eval 'is_valid_sha_format "xyz1234"'
+assert_fails "sha format: empty"         eval 'is_valid_sha_format ""'
+
+# -- parse_job_url -------------------------------------------------------------
+url="https://github.com/tenstorrent/tt-metal/actions/runs/12345678/job/87654321"
+assert "parse_job_url valid" parse_job_url "$url"
+assert_eq "parse_job_url owner"  "$_owner"  "tenstorrent"
+assert_eq "parse_job_url repo"   "$_repo"   "tt-metal"
+assert_eq "parse_job_url run_id" "$_run_id" "12345678"
+assert_eq "parse_job_url job_id" "$_job_id" "87654321"
+
+assert_fails "parse_job_url invalid" parse_job_url "https://example.com/not/a/job"
+assert_fails "parse_job_url empty"   parse_job_url ""
+
+# -- validate_json_file --------------------------------------------------------
+TMP=$(mktemp)
+
+echo '{"ok":true}' > "$TMP"
+assert "validate_json_file valid" validate_json_file "$TMP"
+
+assert_fails "validate_json_file missing" validate_json_file "/no/such/file.json" "quiet"
+
+: > "$TMP"   # empty the file
+assert_fails "validate_json_file empty" validate_json_file "$TMP" "quiet"
+
+echo "not json" > "$TMP"
+assert_fails "validate_json_file invalid content" validate_json_file "$TMP" "quiet"
+
+rm -f "$TMP"
+
+# -- ensure_dirs ---------------------------------------------------------------
+TMP_DIR=$(mktemp -d)
+ensure_dirs "$TMP_DIR/a/b" "$TMP_DIR/c"
+assert "ensure_dirs creates nested" test -d "$TMP_DIR/a/b"
+assert "ensure_dirs creates flat"   test -d "$TMP_DIR/c"
+rm -rf "$TMP_DIR"
+
+# -- double-source guard -------------------------------------------------------
+(
+    source "$LIB_DIR/validation.sh"
+    true
+) && { echo "  PASS  double-source guard"; _pass=$((_pass + 1)); } \
+  || { echo "  FAIL  double-source guard"; _fail=$((_fail + 1)); }
+
+echo ""
+echo "=== $_pass passed, $_fail failed ==="
+[ "$_fail" -eq 0 ]

--- a/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
@@ -57,7 +57,7 @@ assert "ensure_dirs creates nested" test -d "$TMP_DIR/a/b"
 assert "ensure_dirs creates flat"   test -d "$TMP_DIR/c"
 rm -rf "$TMP_DIR"
 
-# -- double-source guard -------------------------------------------------------
+# -- double-source guard (just proves that double-sourcing is a no-op) ---------------------------------------
 (
     source "$LIB_DIR/validation.sh"
     true

--- a/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/validation_test.sh
@@ -9,39 +9,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/lib"
 
+source "$SCRIPT_DIR/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-source "$LIB_DIR/common.sh"
 source "$LIB_DIR/validation.sh"
-
-# -- test harness -------------------------------------------------------------
-_pass=0 _fail=0
-
-assert_eq() {
-    local desc="$1" actual="$2" expected="$3"
-    if [ "$actual" = "$expected" ]; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (got '$actual', expected '$expected')"; _fail=$((_fail + 1))
-    fi
-}
-
-assert() {
-    local desc="$1"; shift
-    if "$@" 2>/dev/null; then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc"; _fail=$((_fail + 1))
-    fi
-}
-
-assert_fails() {
-    local desc="$1"; shift
-    if ! ("$@" 2>/dev/null); then
-        echo "  PASS  $desc"; _pass=$((_pass + 1))
-    else
-        echo "  FAIL  $desc  (expected failure)"; _fail=$((_fail + 1))
-    fi
-}
 
 echo "=== lib/validation.sh ==="
 
@@ -94,6 +64,4 @@ rm -rf "$TMP_DIR"
 ) && { echo "  PASS  double-source guard"; _pass=$((_pass + 1)); } \
   || { echo "  FAIL  double-source guard"; _fail=$((_fail + 1)); }
 
-echo ""
-echo "=== $_pass passed, $_fail failed ==="
-[ "$_fail" -eq 0 ]
+test_summary

--- a/.github/workflows/test-auto-triage-lib.yml
+++ b/.github/workflows/test-auto-triage-lib.yml
@@ -1,0 +1,25 @@
+# Smoke tests for auto-triage lib (common.sh and shared utilities)
+# Runs on push/PR to catch regressions in the refactoring foundation.
+name: Test Auto-Triage Lib
+
+on:
+  push:
+    paths:
+      - '.github/actions/auto-triage/auto_triage/lib/**'
+      - '.github/actions/auto-triage/auto_triage/tests/**'
+  pull_request:
+    paths:
+      - '.github/actions/auto-triage/auto_triage/lib/**'
+      - '.github/actions/auto-triage/auto_triage/tests/**'
+
+jobs:
+  test-lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lib/common.sh smoke tests
+        run: |
+          cd .github/actions/auto-triage/auto_triage
+          chmod +x tests/lib/common_test.sh
+          ./tests/lib/common_test.sh

--- a/.github/workflows/test-auto-triage-lib.yml
+++ b/.github/workflows/test-auto-triage-lib.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '.github/actions/auto-triage/auto_triage/lib/**'
       - '.github/actions/auto-triage/auto_triage/tests/**'
+      - '.github/workflows/test-auto-triage-lib.yml'
   pull_request:
     paths:
       - '.github/actions/auto-triage/auto_triage/lib/**'
       - '.github/actions/auto-triage/auto_triage/tests/**'
+      - '.github/workflows/test-auto-triage-lib.yml'
   workflow_dispatch:
 
 jobs:
@@ -18,4 +20,4 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run lib smoke tests
         working-directory: .github/actions/auto-triage/auto_triage
-        run: ./tests/lib/common_test.sh
+        run: bash ./tests/lib/common_test.sh

--- a/.github/workflows/test-auto-triage-lib.yml
+++ b/.github/workflows/test-auto-triage-lib.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run lib smoke tests
         working-directory: .github/actions/auto-triage/auto_triage
         run: |

--- a/.github/workflows/test-auto-triage-lib.yml
+++ b/.github/workflows/test-auto-triage-lib.yml
@@ -1,5 +1,3 @@
-# Smoke tests for auto-triage lib (common.sh and shared utilities)
-# Runs on push/PR to catch regressions in the refactoring foundation.
 name: Test Auto-Triage Lib
 
 on:
@@ -11,15 +9,13 @@ on:
     paths:
       - '.github/actions/auto-triage/auto_triage/lib/**'
       - '.github/actions/auto-triage/auto_triage/tests/**'
+  workflow_dispatch:
 
 jobs:
   test-lib:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Run lib/common.sh smoke tests
-        run: |
-          cd .github/actions/auto-triage/auto_triage
-          chmod +x tests/lib/common_test.sh
-          ./tests/lib/common_test.sh
+      - name: Run lib smoke tests
+        working-directory: .github/actions/auto-triage/auto_triage
+        run: ./tests/lib/common_test.sh

--- a/.github/workflows/test-auto-triage-lib.yml
+++ b/.github/workflows/test-auto-triage-lib.yml
@@ -20,4 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run lib smoke tests
         working-directory: .github/actions/auto-triage/auto_triage
-        run: bash ./tests/lib/common_test.sh
+        run: |
+          for t in tests/lib/*_test.sh; do
+            echo "--- $t ---"
+            bash "$t"
+          done


### PR DESCRIPTION
## Summary

Third and final foundation PR (stacked on PR #2). Completes Phase 1 of the refactoring plan.

### `lib/github_api.sh` — consistent wrappers around `gh api`

Low-level:
- `gh_api` / `gh_api_jq` / `gh_api_post` — safe wrappers with fallback values and stderr suppression

Workflow/run/job:
- `get_workflow_id` (resolves `.yml`/`.yaml` variants)
- `get_workflow_runs`, `get_jobs_for_run`, `get_job_info`, `get_run_info`

Commit/PR:
- `get_commit_info`, `get_commit_author`
- `get_pr_for_commit`, `get_pr_approvers`, `get_pr_info`

Other:
- `get_check_annotations` (paginated)
- `download_run_logs` (zip download + extract)

### `lib/validation.sh` — input/output validation

- `validate_commit_sha` / `is_valid_sha_format` — git rev-parse wrappers
- `parse_job_url` — regex extraction of owner/repo/run_id/job_id from GitHub URLs
- `validate_json_file` — exists + non-empty + valid JSON (with quiet mode)
- `ensure_dirs` — mkdir -p wrapper

### Tests

- 11 tests for github_api.sh (using a mock `gh` CLI)
- 20 tests for validation.sh
- Full suite: **71 tests** across all 4 lib files, all passing

## What this does NOT change

No existing scripts modified. Purely additive.

## Test plan

- [x] 71 tests pass locally (common: 22, config: 18, github_api: 11, validation: 20)
- [x] Existing scripts unaffected
- [ ] CI workflow triggers and passes

## Stack

- PR #1 (`ebanerjee/refactoring-1`) — `lib/common.sh`
- PR #2 (`ebanerjee/refactoring-2`) — `lib/config.sh`
- **This: PR #3 (`ebanerjee/refactoring-3`)** — `lib/github_api.sh` + `lib/validation.sh`

This completes Phase 1 (Foundation) of the refactoring plan. All subsequent phases (Boundaries, Commit Data, Logs, Analysis, Retry, Auto-fix, Cleanup) depend on these three PRs.

Made with [Cursor](https://cursor.com)